### PR TITLE
feat: add gemini-bridge skill

### DIFF
--- a/.agentic/manifest.yml
+++ b/.agentic/manifest.yml
@@ -58,6 +58,9 @@ skills:
   - name: claude-bridge
     description: Bridges .agentic agents, skills, and workflows into Claude Code and Cowork. Produces thin wrapper files referencing canonical sources.
     path: .agentic/skills/claude-bridge
+  - name: gemini-bridge
+    description: Bridges .agentic agents, skills, and workflows into Gemini CLI. Produces thin wrapper files referencing canonical sources. Use to make any .agentic component available in Gemini CLI.
+    path: .agentic/skills/gemini-bridge
   - name: create-skill
     description: Create a new agent skill following the agentskills.io specification. Use when asked to create a new skill, add a skill to this workspace, or package agent instructions as a reusable, shareable skill.
     path: .agentic/skills/create-skill

--- a/.agentic/skills/gemini-bridge/SKILL.md
+++ b/.agentic/skills/gemini-bridge/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: gemini-bridge
+description: >-
+  Bridges .agentic agents, skills, and workflows into Gemini CLI. Produces
+  thin platform-specific wrapper files that reference canonical sources rather than
+  duplicating them. Use when making any .agentic component available in Gemini CLI.
+compatibility: Gemini CLI
+---
+
+# gemini-bridge
+
+Produces Gemini wrapper files from components defined in `.agentic/`. No content is
+copied from source files — all generated files reference back to their canonical source.
+
+## Artifact Types and Output Paths
+
+| Input | Source | Output |
+|---|---|---|
+| Agent | `.agentic/agents/{name}/IDENTITY.md` | `.gemini/agents/{name}.md` |
+| Skill | `.agentic/skills/{name}/SKILL.md` | `.gemini/skills/{name}/SKILL.md` |
+| Workflow | `.agentic/workflows/{name}/WORKFLOW.md` | `.gemini/commands/{name}.toml` |
+
+## Inputs
+
+- **Type**: one of `agent`, `skill`, or `workflow`
+- **Name**: the directory name under the relevant `.agentic/` subdirectory
+
+## Process: Agent
+
+1. Verify `.agentic/agents/{name}/IDENTITY.md` exists. If not, stop and report.
+2. Read `IDENTITY.md` and extract:
+   - **Role** field: used as the `description` frontmatter value
+   - **Activation** field: appended as a trigger clause to the description
+   - **Scope** field: informs tool selection via [assets/tool-selection.md](assets/tool-selection.md)
+3. Generate `.gemini/agents/{name}.md` using [assets/agent.template.md](assets/agent.template.md)
+4. Create `.gemini/agents/` if it does not exist.
+5. Confirm the output path.
+6. Remind the operator that custom agents are an experimental feature in Gemini CLI and must be enabled in `settings.json` via `"experimental": { "enableAgents": true }`.
+
+## Process: Skill
+
+1. Verify `.agentic/skills/{name}/SKILL.md` exists. If not, stop and report.
+2. Read `SKILL.md` and extract the `name` and `description` frontmatter fields.
+3. Generate `.gemini/skills/{name}/SKILL.md` using [assets/skill.template.md](assets/skill.template.md)
+4. Create `.gemini/skills/{name}/` if it does not exist.
+5. Confirm the output path.
+
+## Process: Workflow
+
+1. Verify `.agentic/workflows/{name}/WORKFLOW.md` exists. If not, stop and report.
+2. Read `WORKFLOW.md` and extract the `name`, `description`, and `invocation` frontmatter fields.
+3. Generate `.gemini/commands/{name}.toml` using [assets/command.template.toml](assets/command.template.toml)
+4. Create `.gemini/commands/` if it does not exist.
+5. Confirm the output path.
+
+## Rules
+
+- Never copy or paraphrase content from source files into generated file bodies. Always reference back.
+- Do not add tools that are not justified by the source artifact's Scope or description. Use [assets/tool-selection.md](assets/tool-selection.md) strictly.
+- The `description` frontmatter value must be derived from the source field, not invented.
+- The `compatibility` frontmatter value is always `Gemini CLI` regardless of the artifact's domain.
+- If a Scope explicitly states no writes or execution, omit all write and execute tools.

--- a/.agentic/skills/gemini-bridge/assets/agent.template.md
+++ b/.agentic/skills/gemini-bridge/assets/agent.template.md
@@ -1,0 +1,11 @@
+---
+name: {agent-name}
+description: {description-from-role}. Activate when {activation-from-identity}.
+tools: [{tools-list}]
+---
+
+# {agent-name}
+
+You are acting as the **{agent-name}** agent. Your identity, operating principles, domain, and scope are defined in the file below. Read it now and follow it for this session.
+
+[.agentic/agents/{agent-name}/IDENTITY.md](.agentic/agents/{agent-name}/IDENTITY.md)

--- a/.agentic/skills/gemini-bridge/assets/command.template.toml
+++ b/.agentic/skills/gemini-bridge/assets/command.template.toml
@@ -1,0 +1,6 @@
+description = "{description-from-workflow}"
+prompt = """
+This command's workflow instructions are defined in the canonical source file below. Read it now and follow every phase and rule it defines.
+
+[.agentic/workflows/{workflow-name}/WORKFLOW.md](.agentic/workflows/{workflow-name}/WORKFLOW.md)
+"""

--- a/.agentic/skills/gemini-bridge/assets/skill.template.md
+++ b/.agentic/skills/gemini-bridge/assets/skill.template.md
@@ -1,0 +1,11 @@
+---
+name: {skill-name}
+description: {description-from-skill}.
+compatibility: Gemini CLI
+---
+
+# {skill-name}
+
+This skill's instructions are defined in the canonical source file below. Read it now and follow it for this session.
+
+[.agentic/skills/{skill-name}/SKILL.md](.agentic/skills/{skill-name}/SKILL.md)

--- a/.agentic/skills/gemini-bridge/assets/tool-selection.md
+++ b/.agentic/skills/gemini-bridge/assets/tool-selection.md
@@ -1,0 +1,60 @@
+# Tool Selection Guide — Gemini Agent Bridge
+
+Use this guide to translate an agent's **Scope** field in `IDENTITY.md` into the correct tool list for the generated agent file.
+
+## Tool Categories
+
+| Category | Tools | Include when… |
+|---|---|---|
+| **read** | `read_file`, `glob`, `grep_search`, `list_directory` | Agent reads files, searches codebases, or inspects project state |
+| **web** | `web_fetch`, `google_web_search` | Agent retrieves external documentation, searches the web, or fetches URLs |
+| **write** | `write_file`, `replace` | Agent modifies or creates files |
+| **execute** | `run_shell_command` | Agent runs commands, scripts, or terminal operations |
+| **orchestrate** | `codebase_investigator`, `generalist`, `cli_help` | Agent spawns sub-agents or performs complex repository-wide analysis |
+| **interactive** | `ask_user` | Agent needs to clarify with or get input from the user |
+
+## Scope → Tool Mapping
+
+### Read-only / Analysis / Audit
+Scope contains words like: *reads*, *analyzes*, *reports*, *reviews*, *does not modify*, *read-only*
+
+```
+tools: ["read_file", "glob", "grep_search", "list_directory", "web_fetch", "google_web_search"]
+```
+
+### Content Creation / Documentation
+Scope contains words like: *writes*, *generates*, *drafts*, *documents*, but no execution or command-running
+
+```
+tools: ["read_file", "glob", "grep_search", "list_directory", "web_fetch", "google_web_search", "write_file", "replace", "ask_user"]
+```
+
+### Engineering / Development
+Scope contains words like: *implements*, *refactors*, *fixes*, *builds*, *runs tests*, *executes*
+
+```
+tools: ["read_file", "glob", "grep_search", "list_directory", "web_fetch", "google_web_search", "write_file", "replace", "run_shell_command", "ask_user"]
+```
+
+### Orchestration / Multi-agent
+Scope contains words like: *coordinates*, *delegates*, *orchestrates*, *spawns agents*, *manages workflows*
+
+```
+tools: ["*"]
+```
+
+## Overrides
+
+- If Scope **explicitly states** the agent does not write, modify, or execute — drop `write_file`, `replace`, and `run_shell_command` regardless of category match.
+- If Scope **explicitly states** the agent does not run commands or scripts — drop `run_shell_command`.
+- If Scope **explicitly states** the agent does not spawn sub-agents — use narrow tool list instead of `*`.
+- When in doubt, choose the **narrower** tool set. It is better to under-grant and let the operator expand than to over-grant.
+
+## Note on Experimental Agents
+Custom agents in Gemini CLI are an experimental feature. They must be enabled in `settings.json` via:
+```json
+"experimental": {
+  "enableAgents": true
+}
+```
+If not enabled, the generated agent files in `.gemini/agents/` will not be recognized by the CLI.

--- a/.gemini/agents/agent-foundry.md
+++ b/.gemini/agents/agent-foundry.md
@@ -1,0 +1,11 @@
+---
+name: agent-foundry
+description: Agent Designer. Activate when scaffolding or modifying agent identities, generating agent skills, or establishing agent workflows.
+tools: ["read_file", "glob", "grep_search", "list_directory", "web_fetch", "google_web_search", "write_file", "replace", "ask_user"]
+---
+
+# agent-foundry
+
+You are acting as the **agent-foundry** agent. Your identity, operating principles, domain, and scope are defined in the file below. Read it now and follow it for this session.
+
+[.agentic/agents/agent-foundry/IDENTITY.md](../.agentic/agents/agent-foundry/IDENTITY.md)

--- a/.gemini/agents/kernel.md
+++ b/.gemini/agents/kernel.md
@@ -1,0 +1,11 @@
+---
+name: kernel
+description: Guide to the Agentic Kernel system. Activate when answering questions about system architecture, how agents interact, memory protocol rules, or when routing tasks to specialized agents.
+tools: ["read_file", "glob", "grep_search", "list_directory", "web_fetch", "google_web_search"]
+---
+
+# kernel
+
+You are acting as the **kernel** agent. Your identity, operating principles, domain, and scope are defined in the file below. Read it now and follow it for this session.
+
+[.agentic/agents/kernel/IDENTITY.md](../.agentic/agents/kernel/IDENTITY.md)

--- a/.gemini/commands/scaffold.toml
+++ b/.gemini/commands/scaffold.toml
@@ -1,0 +1,6 @@
+description = "Materializes the Project Structure from a confirmed spec into real files and directories on the feature branch. Run after /spec, before /plan."
+prompt = """
+This command's workflow instructions are defined in the canonical source file below. Read it now and follow every phase and rule it defines.
+
+[.agentic/workflows/scaffold/WORKFLOW.md](../.agentic/workflows/scaffold/WORKFLOW.md)
+"""

--- a/.gemini/commands/spec.toml
+++ b/.gemini/commands/spec.toml
@@ -1,0 +1,6 @@
+description = "Collaborative, interactive spec creation. Guides user and agent through defining a feature spec, then hands off to /plan to produce a plan."
+prompt = """
+This command's workflow instructions are defined in the canonical source file below. Read it now and follow every phase and rule it defines.
+
+[.agentic/workflows/spec/WORKFLOW.md](../.agentic/workflows/spec/WORKFLOW.md)
+"""

--- a/.gemini/skills/claude-bridge/SKILL.md
+++ b/.gemini/skills/claude-bridge/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: claude-bridge
+description: Bridges .agentic agents, skills, and workflows into Claude Code and Cowork. Produces thin platform-specific wrapper files that reference canonical sources rather than duplicating them. Use when making any .agentic component available in Claude.
+compatibility: Gemini CLI
+---
+
+# claude-bridge
+
+This skill's instructions are defined in the canonical source file below. Read it now and follow it for this session.
+
+[.agentic/skills/claude-bridge/SKILL.md](../../.agentic/skills/claude-bridge/SKILL.md)

--- a/.gemini/skills/copilot-bridge/SKILL.md
+++ b/.gemini/skills/copilot-bridge/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: copilot-bridge
+description: Bridges .agentic agents, skills, and workflows into GitHub Copilot. Produces thin platform-specific wrapper files that reference canonical sources rather than duplicating them. Use when making any .agentic component available in GitHub Copilot Chat.
+compatibility: Gemini CLI
+---
+
+# copilot-bridge
+
+This skill's instructions are defined in the canonical source file below. Read it now and follow it for this session.
+
+[.agentic/skills/copilot-bridge/SKILL.md](../../.agentic/skills/copilot-bridge/SKILL.md)

--- a/.gemini/skills/create-skill/SKILL.md
+++ b/.gemini/skills/create-skill/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: create-skill
+description: Create a new agent skill following the agentskills.io specification. Use this skill when asked to create a new skill, add a skill to this workspace, or package agent instructions as a reusable, shareable skill. Handles directory structure, SKILL.md frontmatter, body content, and optional supporting files.
+compatibility: Gemini CLI
+---
+
+# create-skill
+
+This skill's instructions are defined in the canonical source file below. Read it now and follow it for this session.
+
+[.agentic/skills/create-skill/SKILL.md](../../.agentic/skills/create-skill/SKILL.md)

--- a/.gemini/skills/gemini-bridge/SKILL.md
+++ b/.gemini/skills/gemini-bridge/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: gemini-bridge
+description: Bridges .agentic agents, skills, and workflows into Gemini CLI. Produces thin platform-specific wrapper files that reference canonical sources rather than duplicating them. Use when making any .agentic component available in Gemini CLI.
+compatibility: Gemini CLI
+---
+
+# gemini-bridge
+
+This skill's instructions are defined in the canonical source file below. Read it now and follow it for this session.
+
+[.agentic/skills/gemini-bridge/SKILL.md](../../.agentic/skills/gemini-bridge/SKILL.md)

--- a/.gemini/skills/task-backlog/SKILL.md
+++ b/.gemini/skills/task-backlog/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: task-backlog
+description: Cross-agent task capture and execution protocol. Use when identifying work to defer during an active session, or when asked to list or work through pending tasks. Any agent can capture; any agent can query and execute.
+compatibility: Gemini CLI
+---
+
+# task-backlog
+
+This skill's instructions are defined in the canonical source file below. Read it now and follow it for this session.
+
+[.agentic/skills/task-backlog/SKILL.md](../../.agentic/skills/task-backlog/SKILL.md)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,20 @@ Use the built-in `claude-bridge` skill. It reads the source file for any agent, 
 
 ### Gemini
 
-> **Not yet implemented.** A Gemini bridge skill is planned. When available, it will follow the same pattern: read `IDENTITY.md`, produce a Gemini-native configuration file that references rather than duplicates the canonical identity.
+Use the built-in `gemini-bridge` skill. It reads the source file for any agent, skill, or workflow and generates a thin wrapper under `.gemini/`.
+
+**To bridge a component to Gemini**, ask Gemini:
+
+> "Use the gemini-bridge skill to bridge the `{name}` agent/skill/workflow to Gemini."
+
+| Artifact | Output |
+|---|---|
+| Agent | `.gemini/agents/{name}.md` |
+| Skill | `.gemini/skills/{name}/SKILL.md` |
+| Workflow | `.gemini/commands/{name}.toml` |
+
+**Note**: Custom agents are an experimental feature in Gemini CLI. Ensure `"experimental": { "enableAgents": true }` is set in your `settings.json`.
+
 
 ---
 


### PR DESCRIPTION
Resolves #2

This PR introduces the `gemini-bridge` skill, mapping kernel agents, skills, and workflows to the `.gemini/` directory structure. 

Included changes:
- Created `gemini-bridge` skill and templates.
- Registered the skill in `.agentic/manifest.yml`.
- Updated `README.md` documentation.
- Bootstrapped current kernel components (agents, skills, workflows) into the `.gemini/` structure using the bridge.